### PR TITLE
fix: remove dot at webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,7 @@ const baseConfig = {
       filename: 'index.html',
     }),
     new MiniCssExtractPlugin({
-      filename: '[name].[contenthash].css',
+      filename: '[name][contenthash].css',
     }),
     new CleanWebpackPlugin(),
     new ESLintPlugin({


### PR DESCRIPTION
remove dot, because of which browser can't apply styles properly 